### PR TITLE
Enlarged progressbar and decouple it from title

### DIFF
--- a/src/headerbar.ui
+++ b/src/headerbar.ui
@@ -71,10 +71,10 @@ Author: Nicolai Syvertsen
         </child>
       </object>
     </child>
-    <child type="title">
+    <child>
       <object class="GtkScale" id="scale1">
         <property name="name">seekbar</property>
-        <property name="width_request">200</property>
+        <property name="width_request">400</property>
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="events">GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK</property>

--- a/src/headerbarui.c
+++ b/src/headerbarui.c
@@ -342,7 +342,6 @@ headerbarui_init () {
 
     if (!headerbarui_flag_show_seek_bar)
     {
-        gtk_header_bar_set_custom_title(GTK_HEADER_BAR (headerbar), NULL);
         gtk_widget_hide(headerbar_seekbar);
     }
 


### PR DESCRIPTION
I've changed the progressbar so it would not replace the title and enlarged it from 200 to 400px.

I've done these changes to keep the original title, since this could contain interesting information (artist + track) while scrolling in large playlists. The size of progressbar is here by 400px because the original size has been to small to use it for time picking did it illustrate the track progress to me.
I have tested the changes on a display resolution of 1366x768 and I had no drawbacks because of the increased minimal horizontal size.

Writing this pull request I want to use the chance to thank you for the plugin. Thanks to your plugin deadbeef is the first music player on my system that really fits into the gnome shell.
